### PR TITLE
[IOBP-432] Add `iowallet` scheme in `AndroidManifest`

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="iologin" android:host="127.0.0.1"/>
+        <data android:scheme="iowallet" android:host="127.0.0.1"/>
       </intent-filter>
     </activity>
   </application>


### PR DESCRIPTION
## Short description
This PR adds the support for `iowallet` scheme for Android devices

## List of changes proposed in this pull request
- [android/src/main/AndroidManifest.xml](https://github.com/pagopa/io-react-native-login-utils/compare/add-iowallet-scheme?expand=1#diff-93083d0574bec8be4b25f798b65dd82a612412c23a79dc9bdfdfb4a6b7ab37a3): added `iowallet` scheme

## How to test
You can test this change using the library with an URL starting with `iowallet://`
