### PR TITLE
fix: [IOAPPX-361] Handle browser not found error on Android

### DIFF
--- a/android/src/main/java/com/iologinutils/browser/BrowserHandler.kt
+++ b/android/src/main/java/com/iologinutils/browser/BrowserHandler.kt
@@ -11,6 +11,7 @@ package com.iologinutils.browser
 
 import android.content.ComponentName
 import android.content.Context
+import android.text.TextUtils
 import android.util.Log
 import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
@@ -57,7 +58,10 @@ class BrowserHandler(private val context: Context) {
         clientLatch.countDown()
       }
     }
-    if (!CustomTabsClient.bindCustomTabsService(
+
+    val isBrowserPackageEmpty = TextUtils.isEmpty(browserPackage)
+
+    if (isBrowserPackageEmpty || !CustomTabsClient.bindCustomTabsService(
         context,
         browserPackage,
         connection

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,0 +1,113 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (3.0.7)
+      base64
+      nkf
+      rexml
+    activesupport (7.1.3.4)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
+    algoliasearch (1.27.5)
+      httpclient (~> 2.8, >= 2.8.3)
+      json (>= 1.5.1)
+    atomos (0.1.3)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    claide (1.1.0)
+    cocoapods (1.15.2)
+      addressable (~> 2.8)
+      claide (>= 1.0.2, < 2.0)
+      cocoapods-core (= 1.15.2)
+      cocoapods-deintegrate (>= 1.0.3, < 2.0)
+      cocoapods-downloader (>= 2.1, < 3.0)
+      cocoapods-plugins (>= 1.0.0, < 2.0)
+      cocoapods-search (>= 1.0.0, < 2.0)
+      cocoapods-trunk (>= 1.6.0, < 2.0)
+      cocoapods-try (>= 1.1.0, < 2.0)
+      colored2 (~> 3.1)
+      escape (~> 0.0.4)
+      fourflusher (>= 2.3.0, < 3.0)
+      gh_inspector (~> 1.0)
+      molinillo (~> 0.8.0)
+      nap (~> 1.0)
+      ruby-macho (>= 2.3.0, < 3.0)
+      xcodeproj (>= 1.23.0, < 2.0)
+    cocoapods-core (1.15.2)
+      activesupport (>= 5.0, < 8)
+      addressable (~> 2.8)
+      algoliasearch (~> 1.0)
+      concurrent-ruby (~> 1.1)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 1.0)
+      netrc (~> 0.11)
+      public_suffix (~> 4.0)
+      typhoeus (~> 1.0)
+    cocoapods-deintegrate (1.0.5)
+    cocoapods-downloader (2.1)
+    cocoapods-plugins (1.0.0)
+      nap
+    cocoapods-search (1.0.1)
+    cocoapods-trunk (1.6.0)
+      nap (>= 0.8, < 2.0)
+      netrc (~> 0.11)
+    cocoapods-try (1.2.0)
+    colored2 (3.1.2)
+    concurrent-ruby (1.3.3)
+    connection_pool (2.4.1)
+    drb (2.2.1)
+    escape (0.0.4)
+    ethon (0.16.0)
+      ffi (>= 1.15.0)
+    ffi (1.17.0)
+    fourflusher (2.3.1)
+    fuzzy_match (2.0.4)
+    gh_inspector (1.1.3)
+    httpclient (2.8.3)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
+    json (2.7.2)
+    minitest (5.23.1)
+    molinillo (0.8.0)
+    mutex_m (0.2.0)
+    nanaimo (0.3.0)
+    nap (1.1.0)
+    netrc (0.11.0)
+    nkf (0.2.0)
+    public_suffix (4.0.7)
+    rexml (3.2.9)
+      strscan
+    ruby-macho (2.5.1)
+    strscan (3.1.0)
+    typhoeus (1.4.1)
+      ethon (>= 0.9.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    xcodeproj (1.24.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.3.0)
+      rexml (~> 3.2.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cocoapods (>= 1.11.3)
+
+RUBY VERSION
+   ruby 2.7.7p221
+
+BUNDLED WITH
+   2.1.4

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -78,7 +78,7 @@ PODS:
   - hermes-engine/Pre-built (0.71.19)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
-  - pagopa-io-react-native-login-utils (1.0.0):
+  - pagopa-io-react-native-login-utils (1.0.1):
     - React-Core
   - RCT-Folly (2021.07.22.00):
     - boost
@@ -592,7 +592,7 @@ SPEC CHECKSUMS:
   hermes-engine: 1468b458e81705fcd55ed6e29c32ff069f04b69c
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  pagopa-io-react-native-login-utils: 442a5e2ab8db2c476fed2cff6d7ad16388ff1f21
+  pagopa-io-react-native-login-utils: 9fb43fd59dcc864a24343209e74bd7429659456a
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 79b5f823c2b4b865451ba9ddb33c676786760ea8
   RCTTypeSafety: 4f6d5414413d8848923ccd448c4cef4b6ffcd403


### PR DESCRIPTION
## Short description
This PR adds handling when the device doesn't have a custom tab compatibile browser. This fixes a runtime crash on Android.

## List of changes proposed in this pull request
- Add a null check on the result of `getPackageNameToUse` which returns the name of the compatibile browser. If it's null then the method `bindCustomTabsService()` returns `false` which is handled by the `@ReactMethod` by rejecting the promise;
- (Side changes) Update `Podfile.lock` and `Gemfile.lock`. 

## How to test
- Disable any browser on the Android device. Test the login flow. An exception should be thrown but the app shouldn't crash;
- Enable again the browser and test the login flow. Everything should work as expected.