### PR TITLE
feat: [IOCOM-1683] InApp Browser check

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -71,7 +71,7 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:0.20.1'
-  implementation "androidx.browser:browser:1.4.0"
+  implementation "androidx.browser:browser:1.8.0"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation 'androidx.appcompat:appcompat:1.6.1'
   implementation 'com.google.android.material:material:1.9.0'

--- a/android/src/main/java/com/iologinutils/IoLoginUtilsModule.kt
+++ b/android/src/main/java/com/iologinutils/IoLoginUtilsModule.kt
@@ -3,6 +3,7 @@ package com.iologinutils
 import com.facebook.react.bridge.*
 import com.facebook.react.module.annotations.ReactModule
 import com.iologinutils.IoLoginError.Companion.generateErrorObject
+import com.iologinutils.browser.BrowserPackageHelper
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
@@ -30,6 +31,13 @@ class IoLoginUtilsModule(reactContext: ReactApplicationContext?) :
         generateErrorObject(IoLoginError.Type.MISSING_ACTIVITY_ON_PREPARE)
       )
     }
+  }
+
+  @ReactMethod
+  fun supportsInAppBrowser(promise: Promise) {
+    val customTabBrowserPackageName = BrowserPackageHelper.getPackageNameToUse(reactApplicationContext)
+    val supportsCustomTabs = !customTabBrowserPackageName.isNullOrEmpty()
+    promise.resolve(supportsCustomTabs);
   }
 
   @ReactMethod

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
   ext {
-    buildToolsVersion = "33.0.0"
+    buildToolsVersion = "34.0.0"
     minSdkVersion = 21
-    compileSdkVersion = 33
-    targetSdkVersion = 33
+    compileSdkVersion = 34
+    targetSdkVersion = 34
 
     // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
     ndkVersion = "23.1.7779620"

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -4,6 +4,7 @@ import {
   LoginUtilsError,
   getRedirects,
   openAuthenticationSession,
+  supportsInAppBroser,
 } from '@pagopa/io-react-native-login-utils';
 import { Button, SafeAreaView, StyleSheet, Text, View } from 'react-native';
 
@@ -12,6 +13,9 @@ export default function App() {
   const [redirectResult, setRedirectResult] = React.useState<
     string[] | undefined
   >();
+  const [inAppBrowserSupported, setInAppBrowserSupported] = React.useState<
+    boolean | undefined
+  >(undefined);
 
   React.useEffect(() => {
     console.log('First render!');
@@ -29,6 +33,15 @@ export default function App() {
     <SafeAreaView style={styles.container}>
       <View style={styles.container}>
         <>
+          <Text>
+            {inAppBrowserSupported !== undefined
+              ? `${
+                  inAppBrowserSupported
+                    ? 'InApp Browser Supported'
+                    : 'InApp Browser Unsupported'
+                }`
+              : 'InApp Browser support Unknown yet'}
+          </Text>
           {redirectResult?.map((url, index) => (
             <Text key={index}>Result: {`${index}: ${url}`}</Text>
           ))}
@@ -82,6 +95,16 @@ export default function App() {
               .catch(() => {
                 setAuthResult(undefined);
               });
+          }}
+        />
+      </View>
+      <View style={styles.button}>
+        <Button
+          title="Supports InApp Browser"
+          onPress={() => {
+            supportsInAppBroser().then((supported) =>
+              setInAppBrowserSupported(supported)
+            );
           }}
         />
       </View>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -4,7 +4,7 @@ import {
   LoginUtilsError,
   getRedirects,
   openAuthenticationSession,
-  supportsInAppBroser,
+  supportsInAppBrowser,
 } from '@pagopa/io-react-native-login-utils';
 import { Button, SafeAreaView, StyleSheet, Text, View } from 'react-native';
 
@@ -102,7 +102,7 @@ export default function App() {
         <Button
           title="Supports InApp Browser"
           onPress={() => {
-            supportsInAppBroser().then((supported) =>
+            supportsInAppBrowser().then((supported) =>
               setInAppBrowserSupported(supported)
             );
           }}

--- a/ios/IoLoginUtils.m
+++ b/ios/IoLoginUtils.m
@@ -14,6 +14,8 @@ RCT_EXTERN_METHOD(openAuthenticationSession:(NSString*)url
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(supportsInAppBrowser:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
+
 + (BOOL)requiresMainQueueSetup
 {
   return NO;

--- a/ios/IoLoginUtils.swift
+++ b/ios/IoLoginUtils.swift
@@ -3,6 +3,11 @@ import AuthenticationServices
 @objc(IoLoginUtils)
 class IoLoginUtils: NSObject {
 
+    @objc(supportsInAppBrowser:withRejecter:)
+    func supportsInAppBrowser(resolve:@escaping RCTPromiseResolveBlock, reject:@escaping RCTPromiseRejectBlock) -> Void {
+        resolve(true)
+    }
+
     @objc(getRedirects:withHeaders:withCallbackUrlParameter:withResolver:withRejecter:)
     func getRedirects(for url: String, headers:[String: String],callbackUrlParameter: String,resolve:@escaping RCTPromiseResolveBlock,
                         reject:@escaping RCTPromiseRejectBlock) -> Void {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,3 +72,7 @@ export function openAuthenticationSession(
     shareiOSCookies
   );
 }
+
+export function supportsInAppBroser(): Promise<boolean> {
+  return IoLoginUtils.supportsInAppBrowser();
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -73,6 +73,6 @@ export function openAuthenticationSession(
   );
 }
 
-export function supportsInAppBroser(): Promise<boolean> {
+export function supportsInAppBrowser(): Promise<boolean> {
   return IoLoginUtils.supportsInAppBrowser();
 }


### PR DESCRIPTION
## Short description
This PR adds an utility function to know if the InApp Browser is supported by the system.

## List of changes proposed in this pull request
- New `supportsInAppBrowserFunction`: on Android, it calls `BrowserPackageHelper.getPackageNameToUse` and checks that the returned value is not null nor empty. On iOS, the InApp Browser is always supported so it just returns true 
- Example App has a new button and a feedback text that trigger and display the above function's output
- Android `androidx.browser:browser` package upgraded to latest available (1.8.0)
- Android example app set to use Android 34 SDK and 34.0.0 build tools

## How to test
Launch the example app on iOS and check that it outputs "Supported".
Launch the example app on Android with at least one enabled working browser and check that it outputs "Supported".
Launch the example app on Android with all browsers disabled (or uninstallaed) and check that it outputs "Unsupported".
