### PR TITLE
[IOAPPX-375] Handling of NullPointerException in AuthorizationManagerActivity

### DIFF
--- a/android/src/main/java/com/iologinutils/AuthorizationManagerActivity.kt
+++ b/android/src/main/java/com/iologinutils/AuthorizationManagerActivity.kt
@@ -83,11 +83,10 @@ class AuthorizationManagerActivity : Activity() {
     } ?: savedInstanceState?.let {
       extractState(it)
     } ?: run {
-      IoLoginUtilsModule.authorizationPromise?.reject(
+      IoLoginUtilsModule.rejectAndClearAuthorizationPromise(
         "NativeAuthSessionError",
-        generateErrorObject(IoLoginError.Type.ILLEGAL_STATE_EXCEPTION)
+        IoLoginError.Type.ILLEGAL_STATE_EXCEPTION
       )
-      IoLoginUtilsModule.authorizationPromise = null
     }
   }
 
@@ -148,11 +147,10 @@ class AuthorizationManagerActivity : Activity() {
   private fun handleAuthorizationCanceled() {
     Log.d(TAG, "Authorization flow canceled by user")
 
-    IoLoginUtilsModule.authorizationPromise?.reject(
+    IoLoginUtilsModule.rejectAndClearAuthorizationPromise(
       "NativeAuthSessionError",
-      generateErrorObject(IoLoginError.Type.NATIVE_AUTH_SESSION_CLOSED)
+      IoLoginError.Type.NATIVE_AUTH_SESSION_CLOSED
     )
-    IoLoginUtilsModule.authorizationPromise = null
   }
 
   private fun extractState(state: Bundle) {
@@ -169,20 +167,18 @@ class AuthorizationManagerActivity : Activity() {
 
   private fun handleBrowserNotFound() {
     Log.d(TAG, "Authorization flow canceled due to missing browser")
-    IoLoginUtilsModule.authorizationPromise?.reject(
+    IoLoginUtilsModule.rejectAndClearAuthorizationPromise(
       "NativeAuthSessionError",
-      generateErrorObject(IoLoginError.Type.BROWSER_NOT_FOUND)
+      IoLoginError.Type.BROWSER_NOT_FOUND
     )
-    IoLoginUtilsModule.authorizationPromise = null
   }
 
   private fun handleNullPointerException() {
     Log.d(TAG, "handleNullPointerException")
-    IoLoginUtilsModule.authorizationPromise?.reject(
+    IoLoginUtilsModule.rejectAndClearAuthorizationPromise(
       "NativeAuthSessionError",
-      generateErrorObject(IoLoginError.Type.ANDROID_SYSTEM_FAILURE)
+      IoLoginError.Type.ANDROID_SYSTEM_FAILURE
     )
-    IoLoginUtilsModule.authorizationPromise = null
   }
 
   companion object {

--- a/android/src/main/java/com/iologinutils/IoLoginError.kt
+++ b/android/src/main/java/com/iologinutils/IoLoginError.kt
@@ -12,6 +12,7 @@ class IoLoginError {
     NATIVE_AUTH_SESSION_CLOSED("NativeAuthSessionClosed"),
     BROWSER_NOT_FOUND("BrowserNotFound"),
     ILLEGAL_STATE_EXCEPTION("IllegalStateException"),
+    ANDROID_SYSTEM_FAILURE("AndroidSystemFailure")
   }
 
   companion object {

--- a/android/src/main/java/com/iologinutils/IoLoginUtilsModule.kt
+++ b/android/src/main/java/com/iologinutils/IoLoginUtilsModule.kt
@@ -172,6 +172,14 @@ class IoLoginUtilsModule(reactContext: ReactApplicationContext?) :
     const val name = "IoLoginUtils"
 
     var authorizationPromise: Promise? = null
+
+    fun rejectAndClearAuthorizationPromise(errorCode: String, errorType: IoLoginError.Type) {
+      authorizationPromise?.reject(
+        errorCode,
+        generateErrorObject(errorType)
+      )
+      authorizationPromise = null
+    }
   }
 
   override fun getName() = IoLoginUtilsModule.name


### PR DESCRIPTION
## Short description
This PR handles a case where a `null` instance of the `authIntent` crashes the application.
It also removes references to the `authorizationPromise` after it has been either resolved or rejected.

## List of changes proposed in this pull request
- added a catch to the method that causes the crash
- removal of `authorizationPromise` references

## How to test
Make sure that static checks do succeed and that InApp Browser flows (in the example app) succeed
