### PR TITLE
[IOCOM-1937] Same error handling between Android and iOS

### DIFF
--- a/android/src/main/java/com/iologinutils/AuthorizationManagerActivity.kt
+++ b/android/src/main/java/com/iologinutils/AuthorizationManagerActivity.kt
@@ -7,7 +7,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
-import com.iologinutils.IoLoginError.Companion.generateErrorObject
 
 /**
  * Stores state and handles events related to the authorization flow. The activity is

--- a/android/src/main/java/com/iologinutils/IoLoginError.kt
+++ b/android/src/main/java/com/iologinutils/IoLoginError.kt
@@ -1,7 +1,8 @@
 package com.iologinutils
 
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeArray
-import org.json.JSONObject
+import com.facebook.react.bridge.WritableNativeMap
 
 class IoLoginError {
   enum class Type(val value: String) {
@@ -16,24 +17,22 @@ class IoLoginError {
   }
 
   companion object {
-    fun generateErrorObject(
+    fun generateErrorUserInfo(
       error: Type,
       responseCode: Int? = null,
       url: String? = null,
       parameters: List<String>? = null
-    ): String {
-      return JSONObject().apply {
-        put("error", error.value)
-        responseCode?.let { code -> put("statusCode", code) }
-        url?.let {url ->
-          put("url", url)
-          parameters?.let { params ->
-            put("parameters", WritableNativeArray().apply {
-              params.forEach { param -> pushString(param) }
-            })
-          }
+    ): WritableMap {
+      return WritableNativeMap().apply {
+        putString("error", error.value)
+        url?.let{ it -> putString("url", it)}
+        responseCode?.let { it -> putInt("statusCode", it) }
+        parameters?.let { params ->
+          putArray("parameters", WritableNativeArray().apply {
+            params.forEach { param -> pushString(param) }
+          })
         }
-      }.toString()
+      }
     }
   }
 }

--- a/android/src/main/java/com/iologinutils/IoLoginUtilsModule.kt
+++ b/android/src/main/java/com/iologinutils/IoLoginUtilsModule.kt
@@ -2,7 +2,7 @@ package com.iologinutils
 
 import com.facebook.react.bridge.*
 import com.facebook.react.module.annotations.ReactModule
-import com.iologinutils.IoLoginError.Companion.generateErrorObject
+import com.iologinutils.IoLoginError.Companion.generateErrorUserInfo
 import com.iologinutils.browser.BrowserPackageHelper
 import java.io.IOException
 import java.net.HttpURLConnection
@@ -15,8 +15,8 @@ class IoLoginUtilsModule(reactContext: ReactApplicationContext?) :
   //region custom tabs
   @ReactMethod
   fun openAuthenticationSession(
-    url: String, 
-    callbackURLScheme: String, 
+    url: String,
+    callbackURLScheme: String,
     @Suppress("UNUSED_PARAMETER") shareiOSCookies: Boolean,
     promise: Promise) {
     authorizationPromise = promise
@@ -26,9 +26,8 @@ class IoLoginUtilsModule(reactContext: ReactApplicationContext?) :
         service.performAuthorizationRequest((url))
       }
     } ?: run {
-      promise.reject(
-        "NativeAuthSessionError",
-        generateErrorObject(IoLoginError.Type.MISSING_ACTIVITY_ON_PREPARE)
+      rejectAndClearAuthorizationPromise(
+        "NativeAuthSessionError", IoLoginError.Type.MISSING_ACTIVITY_ON_PREPARE
       )
     }
   }
@@ -59,7 +58,8 @@ class IoLoginUtilsModule(reactContext: ReactApplicationContext?) :
     } catch (e: IOException) {
       promise.reject(
         "NativeRedirectError",
-        generateErrorObject(IoLoginError.Type.FIRST_REQUEST_ERROR)
+        "See user info",
+        generateErrorUserInfo(IoLoginError.Type.FIRST_REQUEST_ERROR)
       )
       return
     }
@@ -84,7 +84,8 @@ class IoLoginUtilsModule(reactContext: ReactApplicationContext?) :
     } catch (e: Exception) {
       promise.reject(
         "NativeRedirectError",
-        generateErrorObject(IoLoginError.Type.CONNECTION_REDIRECT_ERROR)
+        "See user info",
+        generateErrorUserInfo(IoLoginError.Type.CONNECTION_REDIRECT_ERROR)
       )
       return
     }
@@ -105,7 +106,8 @@ class IoLoginUtilsModule(reactContext: ReactApplicationContext?) :
     } catch (e: Exception) {
       promise.reject(
         "NativeRedirectError",
-        generateErrorObject(IoLoginError.Type.CONNECTION_REDIRECT_ERROR)
+        "See user info",
+        generateErrorUserInfo(IoLoginError.Type.CONNECTION_REDIRECT_ERROR)
       )
       return
     }
@@ -139,7 +141,8 @@ class IoLoginUtilsModule(reactContext: ReactApplicationContext?) :
     } else if (responseCode >= 400) {
       promise.reject(
         "NativeRedirectError",
-        generateErrorObject(
+        "See user info",
+        generateErrorUserInfo(
           IoLoginError.Type.REDIRECTING_ERROR,
           responseCode,
           url = getUrlWithoutQuery(url),
@@ -173,10 +176,11 @@ class IoLoginUtilsModule(reactContext: ReactApplicationContext?) :
 
     var authorizationPromise: Promise? = null
 
-    fun rejectAndClearAuthorizationPromise(errorCode: String, errorType: IoLoginError.Type) {
+    fun rejectAndClearAuthorizationPromise(code: String, errorType: IoLoginError.Type) {
       authorizationPromise?.reject(
-        errorCode,
-        generateErrorObject(errorType)
+        code,
+        "See user info",
+        generateErrorUserInfo(errorType)
       )
       authorizationPromise = null
     }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import {
   LoginUtilsError,
   getRedirects,
+  isLoginUtilsError,
   openAuthenticationSession,
   supportsInAppBrowser,
 } from '@pagopa/io-react-native-login-utils';
@@ -25,7 +26,7 @@ export default function App() {
     getRedirects('https://tinyurl.com/testG0', {}, '')
       .then(setRedirectResult)
       .catch((err: LoginUtilsError) => {
-        console.log(err);
+        console.log(`${err.code} ${err.userInfo?.error}`);
       });
   }, []);
 
@@ -61,8 +62,11 @@ export default function App() {
               .then((data) => {
                 setAuthResult(data);
               })
-              .catch(() => {
-                setAuthResult(undefined);
+              .catch((e: unknown) => {
+                if (isLoginUtilsError(e)) {
+                  console.log(`${e.code} ${e.userInfo?.error}`);
+                  setAuthResult(undefined);
+                }
               });
           }}
         />

--- a/ios/IoLoginUtils.swift
+++ b/ios/IoLoginUtils.swift
@@ -13,7 +13,7 @@ class IoLoginUtils: NSObject {
                         reject:@escaping RCTPromiseRejectBlock) -> Void {
         var session: URLSession
         guard let parsedUrl = URL(string: url) else {
-            reject("NativeRedirectError","",generateErrorObject(error: "InvalidURL",responseCode: nil,url: nil,parameters: nil))
+            reject("NativeRedirectError","See user info",generateErrorObject(error: "InvalidURL",responseCode: nil,url: nil,parameters: nil))
             return
         }
         let delegate = RedirectDelegate(callback: callbackUrlParameter, reject: reject)
@@ -29,18 +29,18 @@ class IoLoginUtils: NSObject {
         
         session.dataTask(with: request) { data, response, error in
             if (error != nil) {
-                reject("NativeRedirectError","",generateErrorObject(error: "RequestError",responseCode: nil,url: nil,parameters: nil))
+                reject("NativeRedirectError","See user info",generateErrorObject(error: "RequestError",responseCode: nil,url: nil,parameters: nil))
                 return
             }
             guard let httpResponse = response as? HTTPURLResponse else {
-                reject("NativeRedirectError","",generateErrorObject(error: "InvalidResponse",responseCode: nil,url: nil,parameters: nil))
+                reject("NativeRedirectError","See user info",generateErrorObject(error: "InvalidResponse",responseCode: nil,url: nil,parameters: nil))
                     return
                 }
             if httpResponse.statusCode >= 400 {
                 let urlParameters = getUrlQueryParameters(url: parsedUrl.absoluteString)
                 let urlNoQuery = getUrlNoQuery(url: parsedUrl.absoluteString)
                 let errorObject = generateErrorObject(error: "RedirectingError", responseCode: httpResponse.statusCode, url: urlNoQuery, parameters: urlParameters)
-                reject("NativeRedirectError","",errorObject)
+                reject("NativeRedirectError","See user info",errorObject)
                 return
             }
             resolve(delegate.redirects)
@@ -57,7 +57,7 @@ class IoLoginUtils: NSObject {
                 let urlParameters = getUrlQueryParameters(url: url)
                 let urlNoQuery = getUrlNoQuery(url: url)
                 let errorObject = generateErrorObject(error: "InvalidURL", responseCode: nil, url: urlNoQuery, parameters: urlParameters)
-                reject("NativeAuthSessionError", "", errorObject)
+                reject("NativeAuthSessionError", "See user info", errorObject)
                 return
             }
             
@@ -68,32 +68,32 @@ class IoLoginUtils: NSObject {
                         let nsError = error as NSError
                         if nsError.code == 1 {
                             let errorObject = generateErrorObject(error: "NativeAuthSessionClosed", responseCode: nil, url: nil, parameters: nil)
-                            reject("NativeAuthSessionError", "", errorObject)
+                            reject("NativeAuthSessionError", "See user info", errorObject)
                             return
                         }
                         
                         let errorObject = generateErrorObject(error: "MissingResponseURL", responseCode: nil, url: nil, parameters: nil)
-                        reject("NativeAuthSessionError", "", errorObject)
+                        reject("NativeAuthSessionError", "See user info", errorObject)
                         return
                     }
                     let urlParameters = getUrlQueryParameters(url: url.absoluteString)
                     let urlNoQuery = getUrlNoQuery(url: url.absoluteString)
                     let errorObject = generateErrorObject(error: "ErrorOnResponseOrNativeComponent", responseCode: nil, url: urlNoQuery, parameters: urlParameters)
-                    reject("NativeAuthSessionError", "", errorObject)
+                    reject("NativeAuthSessionError", "See user info", errorObject)
                     return
                 } else if let url = url {
                     resolve(url.absoluteString)
                     return
                 } else {
                     let errorObject = generateErrorObject(error: "GenericErrorOnResponse", responseCode: nil, url: nil, parameters: nil)
-                    reject("NativeAuthSessionError", "", errorObject)
+                    reject("NativeAuthSessionError", "See user info", errorObject)
                     return
                 }
             }
             
             guard let authSession = authSession else {
                 let errorObject = generateErrorObject(error: "NativeComponentNotInstantiated", responseCode: nil, url: nil, parameters: nil)
-                reject("NativeAuthSessionError", "", errorObject)
+                reject("NativeAuthSessionError", "See user info", errorObject)
                 return
             }
             authSession.prefersEphemeralWebBrowserSession = !shareiOSCookies
@@ -102,7 +102,7 @@ class IoLoginUtils: NSObject {
         }
         else{
             let errorObject = generateErrorObject(error: "iOSVersionNotSupported", responseCode: nil, url: nil, parameters: nil)
-            reject("NativeAuthSessionError", "", errorObject)
+            reject("NativeAuthSessionError", "See user info", errorObject)
             return
         }
         
@@ -134,7 +134,7 @@ class RedirectDelegate: NSObject, URLSessionTaskDelegate {
         if response.statusCode >= 300 && response.statusCode <= 399 {
             guard let newUrl = request.url?.absoluteString else {
                 let errorObject = generateErrorObject(error: "RedirectingErrorMissingURL", responseCode: nil, url: nil, parameters: nil)
-                reject("NativeRedirectError","",errorObject)
+                reject("NativeRedirectError","See user info",errorObject)
                 return
             }
             redirects.append(newUrl)
@@ -148,7 +148,7 @@ class RedirectDelegate: NSObject, URLSessionTaskDelegate {
             let urlParameters = getUrlQueryParameters(url: redirects.last ?? "")
             let urlNoQuery = getUrlNoQuery(url: redirects.last ?? "")
             let errorObject = generateErrorObject(error: "RedirectingError", responseCode: response.statusCode, url: urlNoQuery, parameters: urlParameters)
-            reject("NativeRedirectError","",errorObject)
+            reject("NativeRedirectError","See user info",errorObject)
             completionHandler(nil)
             return
         }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -44,7 +44,7 @@ export type AndroidError =
 export type Error = IOSError | AndroidError;
 
 export type LoginUtilsError = {
-  userInfo?: {
+  userInfo: {
     error: Error;
     url: string | undefined;
     statusCode: number | undefined;
@@ -52,6 +52,9 @@ export type LoginUtilsError = {
   };
   code: AreaError;
 };
+
+export const isLoginUtilsError = (e: unknown): e is LoginUtilsError =>
+  (e as LoginUtilsError).userInfo !== undefined;
 
 export function getRedirects(
   url: string,


### PR DESCRIPTION
## Short description
Same error handling between Android and iOS. Previously, Android and iOS error information was passed back to react-native using a different format. Now `userInfo` has the same data structure for both systems

## List of changes proposed in this pull request
- Android error generation aligned to iOS
- Added an informative "See user info" to the generic error message field

## How to test
Run the example application on both Android and iOS. Open the InAp Browser and close it. The logged error should be the same for both systems.
