### PR TITLE
[IOCOM-2008] Add `iossoapi` to Android manifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
         <category android:name="android.intent.category.BROWSABLE" />
 
         <data android:scheme="iologin" />
+        <data android:scheme="iossoapi" />
         <data android:scheme="iowallet" />
       </intent-filter>
 


### PR DESCRIPTION
## Short description
This PR adds `iossoapi` protocol to receive data back when using the InApp Browser with FIMS

## List of changes proposed in this pull request
- `iossoapi` protocol added to Android Manifest

## How to test
Using the example application, check that any url in the web page with the `iossoapi` protocol closes the InApp Browser, sending back its data to the calling application.
